### PR TITLE
added overflow: hidden to particles container

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
         width: 100%;
         height: 100%;
         z-index: -1;
+        overflow: hidden;
       }
 
       .particle {


### PR DESCRIPTION
Hello again,

I noticed, that if you open your website on a phone (iPhone SE 2. in my case), one was able to scoll to the right because of the particle divs.

I gave the parent div "particles" an overflow: hidden.

But that scrolling is not possible anymore.

Daniel